### PR TITLE
Update GDACS RSS feed URL

### DIFF
--- a/dataqs/gdacs/gdacs.py
+++ b/dataqs/gdacs/gdacs.py
@@ -21,7 +21,8 @@ class GDACSProcessor(GeoDataProcessor):
     prefix = "gdacs_alerts"
     layer_title = 'Flood, Quake, Cyclone Alerts - GDACS'
     params = {}
-    base_url = "http://www.gdacs.org/rss.aspx?profile=ARCHIVE&from={}&to={}"
+    base_url = \
+        "http://www.gdacs.org/rss.gdacs.aspx?profile=ARCHIVE&from={}&to={}"
 
     def __init__(self, *args, **kwargs):
         for key in kwargs.keys():


### PR DESCRIPTION
The RSS feed URL for GDACS has changed, the original URL no longer works.
