### PR TITLE
Fix wrong layer titles

### DIFF
--- a/dataqs/wqp/resources/wqp_api_escherichiacoli_map.sld
+++ b/dataqs/wqp/resources/wqp_api_escherichiacoli_map.sld
@@ -3,7 +3,7 @@
     <sld:Name>wqp_api_escherichiacoli_map</sld:Name>
     <sld:UserStyle>
       <sld:Name>wqp_api_escherichiacoli_map</sld:Name>
-      <sld:Title>point</sld:Title>
+      <sld:Title>Escherichia coli (Water Quality)</sld:Title>
       <sld:IsDefault>1</sld:IsDefault>
       <sld:FeatureTypeStyle>
         <sld:Name>name</sld:Name>

--- a/dataqs/wqp/resources/wqp_api_inorganicnitrogennitrateandnitrite_map.sld
+++ b/dataqs/wqp/resources/wqp_api_inorganicnitrogennitrateandnitrite_map.sld
@@ -3,7 +3,7 @@
     <sld:Name>wqp_api_inorganicnitrogennitrateandnitrite_map</sld:Name>
     <sld:UserStyle>
       <sld:Name>wqp_api_inorganicnitrogennitrateandnitrite_map</sld:Name>
-      <sld:Title>point</sld:Title>
+      <sld:Title>Inorganic Nitrogen Nitrate Nitrite (Water Quality)</sld:Title>
       <sld:IsDefault>1</sld:IsDefault>
       <sld:FeatureTypeStyle>
         <sld:Name>name</sld:Name>

--- a/dataqs/wqp/resources/wqp_api_oxygen_map.sld
+++ b/dataqs/wqp/resources/wqp_api_oxygen_map.sld
@@ -3,7 +3,7 @@
     <sld:Name>wqp_api_oxygen_map</sld:Name>
     <sld:UserStyle>
       <sld:Name>wqp_api_oxygen_map</sld:Name>
-      <sld:Title>point</sld:Title>
+      <sld:Title>Oxygen (Water Quality)</sld:Title>
       <sld:IsDefault>1</sld:IsDefault>
       <sld:FeatureTypeStyle>
         <sld:Name>name</sld:Name>

--- a/dataqs/wqp/resources/wqp_api_ph_map.sld
+++ b/dataqs/wqp/resources/wqp_api_ph_map.sld
@@ -3,7 +3,7 @@
     <sld:Name>wqp_api_ph_map</sld:Name>
     <sld:UserStyle>
       <sld:Name>wqp_api_ph_map</sld:Name>
-      <sld:Title>point</sld:Title>
+      <sld:Title>pH (Water Quality)</sld:Title>
       <sld:IsDefault>1</sld:IsDefault>
       <sld:FeatureTypeStyle>
         <sld:Name>name</sld:Name>

--- a/dataqs/wqp/resources/wqp_api_phosphorus_map.sld
+++ b/dataqs/wqp/resources/wqp_api_phosphorus_map.sld
@@ -3,7 +3,7 @@
     <sld:Name>wqp_api_phosphorus_map</sld:Name>
     <sld:UserStyle>
       <sld:Name>wqp_api_phosphorus_map</sld:Name>
-      <sld:Title>point</sld:Title>
+      <sld:Title>Phosphorus (Water Quality)</sld:Title>
       <sld:IsDefault>1</sld:IsDefault>
       <sld:FeatureTypeStyle>
         <sld:Name>name</sld:Name>
@@ -140,4 +140,3 @@
     </sld:UserStyle>
   </sld:NamedLayer>
 </sld:StyledLayerDescriptor>
-

--- a/dataqs/wqp/resources/wqp_api_specificconductance_map.sld
+++ b/dataqs/wqp/resources/wqp_api_specificconductance_map.sld
@@ -3,7 +3,7 @@
     <sld:Name>wqp_api_specificconductance_map</sld:Name>
     <sld:UserStyle>
       <sld:Name>wqp_api_specificconductance_map</sld:Name>
-      <sld:Title>point</sld:Title>
+      <sld:Title>Specific Conductance (Water Quality)</sld:Title>
       <sld:IsDefault>1</sld:IsDefault>
       <sld:FeatureTypeStyle>
         <sld:Name>name</sld:Name>

--- a/dataqs/wqp/resources/wqp_api_temperaturewater_map.sld
+++ b/dataqs/wqp/resources/wqp_api_temperaturewater_map.sld
@@ -3,7 +3,7 @@
     <sld:Name>wqp_api_temperaturewater_map</sld:Name>
     <sld:UserStyle>
       <sld:Name>wqp_api_temperaturewater_map</sld:Name>
-      <sld:Title>point</sld:Title>
+      <sld:Title>Temperature (Water Quality)</sld:Title>
       <sld:IsDefault>1</sld:IsDefault>
       <sld:FeatureTypeStyle>
         <sld:Name>name</sld:Name>


### PR DESCRIPTION
This PR aims to remove the wrong title names that appears on Minerva/Geoviz. Some layers just appear with the title "point". This PR fixes that.

@aashish24 PTAL