### PR TITLE
Overwrite if extra keywords already exist

### DIFF
--- a/dataqs/helpers.py
+++ b/dataqs/helpers.py
@@ -393,6 +393,9 @@ def add_keywords(keyword_list, extra_keywords):
                       if k.startswith('category:') or k.startswith('datetime:')]
 
     if keywords_added:
-        return keyword_list[:len(extra_keywords)-1] + extra_keywords
+        filtered_keywords = [k for k in keyword_list
+                             if not k.startswith('category:') or
+                             not k.startswith('datetime:')]
+        return filtered_keywords + extra_keywords
     else:
         return keyword_list + extra_keywords

--- a/dataqs/helpers.py
+++ b/dataqs/helpers.py
@@ -388,14 +388,8 @@ def add_keywords(keyword_list, extra_keywords):
 
     # check if datetime and category already exist in the
     # keyword list
+    filtered_keywords = [k for k in keyword_list if not
+                         (k.startswith('category:') or
+                          k.startswith('datetime:'))]
 
-    keywords_added = [k for k in keyword_list
-                      if k.startswith('category:') or k.startswith('datetime:')]
-
-    if keywords_added:
-        filtered_keywords = [k for k in keyword_list
-                             if not k.startswith('category:') or
-                             not k.startswith('datetime:')]
-        return filtered_keywords + extra_keywords
-    else:
-        return keyword_list + extra_keywords
+    return filtered_keywords + extra_keywords

--- a/dataqs/helpers.py
+++ b/dataqs/helpers.py
@@ -381,3 +381,18 @@ class MockResponse(object):
 
     def raise_for_status(self):
         pass
+
+
+def add_keywords(keyword_list, extra_keywords):
+    """Adds extra_keywords list to the keyword_list"""
+
+    # check if datetime and category already exist in the
+    # keyword list
+
+    keywords_added = [k for k in keyword_list
+                      if k.startswith('category:') or k.startswith('datetime:')]
+
+    if keywords_added:
+        return keyword_list[:len(extra_keywords)-1] + extra_keywords
+    else:
+        return keyword_list + extra_keywords

--- a/dataqs/processor_base.py
+++ b/dataqs/processor_base.py
@@ -31,7 +31,7 @@ import datetime
 import requests
 from django.conf import settings
 import shutil
-from dataqs.helpers import get_html
+from dataqs.helpers import get_html, add_keywords
 from geonode.geoserver.helpers import ogc_server_settings, gs_catalog, get_store
 from geonode.geoserver.management.commands.updatelayers import Command \
     as UpdateLayersCommand
@@ -268,9 +268,11 @@ class GeoDataProcessor(object):
                 gs_catalog.save(res)
             if extra_keywords:
                 assert isinstance(extra_keywords, list)
+                now = datetime.datetime.now().isoformat()
+                extra_keywords.append('datetime:{}'.format(now))
                 # Append extra keywords to the default ones
                 res = lyr.gs_resource
-                keywords = res.keywords + extra_keywords
+                keywords = add_keywords(res.keywords, extra_keywords)
                 res.keywords = keywords
                 _user, _password = ogc_server_settings.credentials
                 url = ogc_server_settings.rest


### PR DESCRIPTION
Overrides the extra keywords if they already exist.
Adds datetime in ISO format.

The new metadata looks something like:

![selection_016](https://cloud.githubusercontent.com/assets/11761461/22303023/68b0940a-e2ff-11e6-84e1-29a0d2ccfd5a.jpg)

@jbeezley PTAL